### PR TITLE
Feature/run smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The script runs the following loop, until being stopped:
 - Move the zip file to its expected location by rocket-e2e
 - Update the rocket-e2e repo to the latest git develop branch.
 - Run rocket-e2e (with specific options)
-- Logs & sends to Slack the result of the run
+- Copy & Rename the `wp-rocket-e2e/test-results` folder in `wp-rocket-e2e/test-results-storage`. Results are stored for 4 days.
+- Logs & sends to Slack the result of the run (#wpmedia_auto-e2e-reports)
 - Wait a few minutes before starting another run.
 
 **How to run**

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -238,11 +238,11 @@ class WPRocketMonitor {
     });
   }
 
-  async runSmokeTests() {
-    this.log('Running Smoke Tests...');
+  async runE2ETests() {
+    this.log('Running E2E Tests...');
     
     return new Promise((resolve) => {
-      const process = spawn('npm', ['run', 'test:smoke'], {
+      const process = spawn('npm', ['run', 'test:e2e'], {
         cwd: CONFIG.E2E_DIR,
         stdio: 'pipe'
       });
@@ -259,9 +259,9 @@ class WPRocketMonitor {
       });
 
       process.on('close', (code) => {
-        this.log(`Smoke tests completed with exit code: ${code}`);
-        if (stdout.trim()) this.log(`Smoke tests stdout: ${stdout.trim()}`);
-        if (stderr.trim()) this.log(`Smoke tests stderr: ${stderr.trim()}`);
+        this.log(`E2E tests completed with exit code: ${code}`);
+        if (stdout.trim()) this.log(`E2E tests stdout: ${stdout.trim()}`);
+        if (stderr.trim()) this.log(`E2E tests stderr: ${stderr.trim()}`);
         
         resolve({
           code,
@@ -271,7 +271,7 @@ class WPRocketMonitor {
       });
 
       process.on('error', (error) => {
-        this.log(`Smoke tests process error: ${error.message}`);
+        this.log(`E2E tests process error: ${error.message}`);
         resolve({
           code: 1,
           stdout,
@@ -328,16 +328,16 @@ class WPRocketMonitor {
       
       // Step 5: Run the test suite
       //const result = await this.runHealthcheck();
-      const result = await this.runSmokeTests();
+      const result = await this.runE2ETests();
       
       // Step 6: Check exit code and send notification if needed
       var errorMessage = '';
       if (result.code === 0) {
-        this.log('✅ Smoke tests passed successfully');
-        errorMessage = `✅ WP Rocket E2E Smoke tests Ran Successfully!`;
+        this.log('✅ E2E tests passed successfully');
+        errorMessage = `✅ WP Rocket E2E tests Ran Successfully!`;
       } else {
-        this.log('❌ Smoke tests failed');
-        errorMessage = `❌ WP Rocket E2E Smoke tests Failed!`;
+        this.log('❌ E2E tests failed');
+        errorMessage = `❌ WP Rocket E2E tests Failed!`;
       }
       await this.sendSlackMessage(errorMessage);
       

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -350,8 +350,8 @@ async saveTestResults() {
       await this.updateE2ERepo();
       
       // Step 5: Run the test suite
-      //const result = await this.runHealthcheck();
-      const result = await this.runE2ETests();
+      const result = await this.runHealthcheck();
+      //const result = await this.runE2ETests();
       
       // Step 6: Check exit code and send notification if needed
       var errorMessage = '';

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -47,7 +47,7 @@ const CONFIG = {
   LOOP_INTERVAL: 5 * 60 * 1000, // 5 minutes in milliseconds
   
   // Logging
-  LOG_FILE: '/home/ubuntu/wp-rocket-monitor.log'
+  LOG_FILE: `${BASE_DIR}/wp-rocket-monitor.log`
 };
 
 class WPRocketMonitor {

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -36,7 +36,7 @@ const CONFIG = {
   WP_ROCKET_CLONE_DIR: `${BASE_DIR}/wp-rocket`,
   E2E_DIR: `${BASE_DIR}/wp-rocket-e2e`,
   PLUGIN_DIR: `${BASE_DIR}/wp-rocket-e2e/plugin`,
-  RESULTS_DIR: `${E2E_DIR}/test-results-storage`,
+  RESULTS_DIR: `${BASE_DIR}/wp-rocket-e2e/test-results-storage`,
   
   // GitHub
   WP_ROCKET_REPO: 'https://github.com/wp-media/wp-rocket.git', // Update with actual repo URL

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -7,7 +7,7 @@ const { spawn, exec } = require('child_process');
 const { promisify } = require('util');
 
 
-const BASE_DIR = '/home/ubuntu';
+const BASE_DIR = path.dirname(path.dirname(__filename));
 // Simple synchronous .env loader
 function loadEnv() {
   try {

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -350,8 +350,8 @@ async saveTestResults() {
       await this.updateE2ERepo();
       
       // Step 5: Run the test suite
-      const result = await this.runHealthcheck();
-      //const result = await this.runE2ETests();
+      //const result = await this.runHealthcheck();
+      const result = await this.runE2ETests();
       
       // Step 6: Check exit code and send notification if needed
       var errorMessage = '';

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -155,7 +155,7 @@ class WPRocketMonitor {
     
     this.log('Checking for generated ZIP file...');
     const zipPath = path.join(CONFIG.WORK_DIR, 'wp-rocket.zip');
-    if (!fs.existsSync(zipPath)) {
+    if (!fssync.existsSync(zipPath)) {
         throw new Error('No WP Rocket ZIP file found after compilation');
     }
     

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -11,7 +11,7 @@ const execAsync = promisify(exec);
 const BASE_DIR = '/home/ubuntu';
 // Simple synchronous .env loader
 function loadEnv() {
-  //try {
+  try {
     const envPath = `${BASE_DIR}/auto-e2e/.env`;
     const envFile = fssync.readFileSync(envPath, 'utf8');
     
@@ -21,9 +21,9 @@ function loadEnv() {
         process.env[key.trim()] = value.trim();
       }
     });
-  //} catch (error) {
-    // .env file doesn't exist or can't be read - that's okay
-  //}
+  } catch (error) {
+     //.env file doesn't exist or can't be read - that's okay
+  }
 }
 
 // Load environment variables
@@ -161,7 +161,7 @@ class WPRocketMonitor {
     const zipName = path.basename(zipPath);
     this.log(`Generated ZIP file: ${zipName}`);
     
-    return { zipPath, zipName };
+    return zipPath;
     
   } catch (error) {
     this.log(`Failed to compile WP Rocket: ${error.message}`);
@@ -169,19 +169,19 @@ class WPRocketMonitor {
   }
 }
 
-  async moveZipToPlugin(zipPath, zipName) {
+  async moveZipToPlugin(zipPath) {
     this.log('Moving ZIP to plugin directory...');
     
     await this.createDirectoryIfNeeded(CONFIG.PLUGIN_DIR);
     
     // Remove old wp-rocket zips to avoid clutter
     try {
-      await this.executeCommand(`rm -f ${CONFIG.PLUGIN_DIR}/wp-rocket.zip`);
+      await this.executeCommand(`rm -f ${CONFIG.PLUGIN_DIR}/new_release.zip`);
     } catch (error) {
       this.log('No old ZIP files to remove (or removal failed)');
     }
     
-    const destinationPath = path.join(CONFIG.PLUGIN_DIR, zipName);
+    const destinationPath = path.join(CONFIG.PLUGIN_DIR, 'new_release.zip');
     await this.executeCommand(`mv ${zipPath} ${destinationPath}`);
     
     return destinationPath;
@@ -310,10 +310,10 @@ class WPRocketMonitor {
       await this.cloneOrUpdateWPRocket();
       
       // Step 2: Create ZIP
-      const { zipPath, zipName } = await this.zipWPRocket();
+      const zipPath = await this.zipWPRocket();
       
       // Step 3: Move ZIP to plugin directory
-      await this.moveZipToPlugin(zipPath, zipName);
+      await this.moveZipToPlugin(zipPath);
       
       // Step 4: Update E2E repo
       await this.updateE2ERepo();

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -202,39 +202,17 @@ class WPRocketMonitor {
     return new Promise((resolve) => {
       const process = spawn('npm', ['run', 'healthcheck'], {
         cwd: CONFIG.E2E_DIR,
-        stdio: 'pipe'
+        stdio: 'inherit' // This will show output in real-time
       });
 
-      let stdout = '';
-      let stderr = '';
-
-      process.stdout.on('data', (data) => {
-        stdout += data.toString();
-      });
-
-      process.stderr.on('data', (data) => {
-        stderr += data.toString();
-      });
-
-      process.on('close', (code) => {
+       process.on('close', (code) => {
         this.log(`Healthcheck completed with exit code: ${code}`);
-        if (stdout.trim()) this.log(`Healthcheck stdout: ${stdout.trim()}`);
-        if (stderr.trim()) this.log(`Healthcheck stderr: ${stderr.trim()}`);
-        
-        resolve({
-          code,
-          stdout,
-          stderr
-        });
+        resolve({ code });
       });
 
       process.on('error', (error) => {
         this.log(`Healthcheck process error: ${error.message}`);
-        resolve({
-          code: 1,
-          stdout,
-          stderr: error.message
-        });
+        resolve({ code: 1 });
       });
     });
   }
@@ -245,39 +223,17 @@ class WPRocketMonitor {
     return new Promise((resolve) => {
       const process = spawn('npm', ['run', 'test:e2e'], {
         cwd: CONFIG.E2E_DIR,
-        stdio: 'pipe'
+        stdio: 'inherit' // This will show output in real-time
       });
 
-      let stdout = '';
-      let stderr = '';
-
-      process.stdout.on('data', (data) => {
-        stdout += data.toString();
-      });
-
-      process.stderr.on('data', (data) => {
-        stderr += data.toString();
-      });
-
-      process.on('close', (code) => {
+       process.on('close', (code) => {
         this.log(`E2E tests completed with exit code: ${code}`);
-        if (stdout.trim()) this.log(`E2E tests stdout: ${stdout.trim()}`);
-        if (stderr.trim()) this.log(`E2E tests stderr: ${stderr.trim()}`);
-        
-        resolve({
-          code,
-          stdout,
-          stderr
-        });
+        resolve({ code });
       });
 
       process.on('error', (error) => {
         this.log(`E2E tests process error: ${error.message}`);
-        resolve({
-          code: 1,
-          stdout,
-          stderr: error.message
-        });
+        resolve({ code: 1 });
       });
     });
   }
@@ -309,20 +265,20 @@ async deleteOldTestResults() {
   
   try {
     // Check if results directory exists
-    const dirExists = await this.checkPathExists(RESULTS_DIR);
+    const dirExists = await this.checkPathExists(CONFIG.RESULTS_DIR);
     if (!dirExists) {
       this.log('Test results storage directory does not exist, skipping cleanup');
       return;
     }
 
-    const files = await fs.readdir(RESULTS_DIR);
+    const files = await fs.readdir(CONFIG.RESULTS_DIR);
     const now = Date.now();
     const fourDaysAgo = now - (4 * 24 * 60 * 60 * 1000); // 4 days in milliseconds
     
     let deletedCount = 0;
     
     for (const file of files) {
-      const filePath = path.join(RESULTS_DIR, file);
+      const filePath = path.join(CONFIG.RESULTS_DIR, file);
       
       try {
         const stats = await fs.stat(filePath);

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -309,7 +309,7 @@ async deleteOldTestResults() {
   
   try {
     // Check if results directory exists
-    const dirExists = await this.pathExists(RESULTS_DIR);
+    const dirExists = await this.checkPathExists(RESULTS_DIR);
     if (!dirExists) {
       this.log('Test results storage directory does not exist, skipping cleanup');
       return;
@@ -351,7 +351,7 @@ async saveTestResults() {
   
   try {
     // Check if source directory exists and has content
-    const sourceExists = await this.pathExists(sourceDir);
+    const sourceExists = await this.checkPathExists(sourceDir);
     if (!sourceExists) {
       this.log('No test-results directory found, skipping save');
       return;

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -53,7 +53,7 @@ const CONFIG = {
 class WPRocketMonitor {
   constructor() {
     this.isRunning = false;
-    this.isTestRunning = false;
+    this.isCycleRunning = false;
   }
 
   async log(message) {
@@ -155,7 +155,7 @@ class WPRocketMonitor {
     
     this.log('Checking for generated ZIP file...');
     const zipPath = path.join(CONFIG.WORK_DIR, 'wp-rocket.zip');
-    if (!zipPath) {
+    if (!fs.existsSync(zipPath)) {
         throw new Error('No WP Rocket ZIP file found after compilation');
     }
     
@@ -331,13 +331,13 @@ async saveTestResults() {
       const result = await this.runE2ETests(testSuite);
       
       // Step 6: Check exit code and send notification if needed
-      var errorMessage = '';
+      let slackMessage = '';
       if (result.code === 0) {
         this.log(`✅ E2E tests ${testSuite} passed successfully`);
-        errorMessage = `✅ WP Rocket E2E tests ${testSuite} Ran Successfully!`;
+        slackMessage = `✅ WP Rocket E2E tests ${testSuite} Ran Successfully!`;
       } else {
         this.log(`❌ E2E tests ${testSuite} failed`);
-        errorMessage = `❌ WP Rocket E2E tests ${testSuite} Failed!`;
+        slackMessage = `❌ WP Rocket E2E tests ${testSuite} Failed!`;
       }
       await this.sendSlackMessage(errorMessage);
       

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -339,7 +339,7 @@ async saveTestResults() {
         this.log(`❌ E2E tests ${testSuite} failed`);
         slackMessage = `❌ WP Rocket E2E tests ${testSuite} Failed!`;
       }
-      await this.sendSlackMessage(errorMessage);
+      await this.sendSlackMessage(slackMessage);
       
       // Step 7: Maintain test results
       await this.deleteOldTestResults();


### PR DESCRIPTION
# Description

⚠️ This is the first PR review for the whole repo. It should be about the whole script.

The script allows to run rocket-e2e continuously on a dedicated server, store the results and get an update on Slack.
More info in the Readme.md and https://www.notion.so/wpmedia/auto-e2e-servers-217ed22a22f0808ea044ce092c342a54?source=copy_link

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

The script is running for a few days on the dedicated server.

### How to test

See Readme.md and https://www.notion.so/wpmedia/auto-e2e-servers-217ed22a22f0808ea044ce092c342a54?source=copy_link

## Technical description

### Documentation

See Readme.md and https://www.notion.so/wpmedia/auto-e2e-servers-217ed22a22f0808ea044ce092c342a54?source=copy_link

### New dependencies

NA

### Risks

NA

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
