### PR TITLE
Add the scp command to Slack messages to download the results easily

### DIFF
--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -12,7 +12,7 @@ const BASE_DIR = path.dirname(path.dirname(__filename));
 // Simple synchronous .env loader
 function loadEnv() {
   try {
-    const envPath = `${BASE_DIR}/auto-e2e/.env`;
+    const envPath = `${BASE_DIR}/.env`;
     const envFile = fssync.readFileSync(envPath, 'utf8');
     
     envFile.split('\n').forEach(line => {
@@ -348,8 +348,7 @@ async saveTestResults() {
       }
       // Add SCP download command if results were saved to facilitate downloading
       if (resultTimestamp) {
-        const timestamp = path.basename(savedResultsPath);
-        slackMessage += `\n\nDownload test report:\n\`\`\`scp auto-e2e-wpr@xx.xx.xx.xx:~/wp-rocket-e2e/test-results-storage/${timestamp}/cucumber-report.html ${timestamp}.html\`\`\``;
+        slackMessage += `\n\nDownload test report:\n\`\`\`scp auto-e2e-wpr@xx.xx.xx.xx:~/wp-rocket-e2e/test-results-storage/${resultTimestamp}/cucumber-report.html ${resultTimestamp}.html\`\`\``;
       }
 
       await this.sendSlackMessage(slackMessage);


### PR DESCRIPTION
# Description

The scp command to download the test results locally is now sent with the Slack message to facilitate downloading.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Running the script on the auto-e2e server and checking the message in Slack.

### How to test

See above

## Technical description

### Documentation

NA

### New dependencies

NA

### Risks

NA

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
