### PR TITLE
Fix/parse json report for status

### DIFF
--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -12,7 +12,7 @@ const BASE_DIR = path.dirname(path.dirname(__filename));
 // Simple synchronous .env loader
 function loadEnv() {
   try {
-    const envPath = `${BASE_DIR}/auto-e2e/.env`;
+    const envPath = `${BASE_DIR}/.env`;
     const envFile = fssync.readFileSync(envPath, 'utf8');
     
     envFile.split('\n').forEach(line => {
@@ -348,8 +348,7 @@ async saveTestResults() {
       }
       // Add SCP download command if results were saved to facilitate downloading
       if (resultTimestamp) {
-        const timestamp = path.basename(savedResultsPath);
-        slackMessage += `\n\nDownload test report:\n\`\`\`scp auto-e2e-wpr@xx.xx.xx.xx:~/wp-rocket-e2e/test-results-storage/${timestamp}/cucumber-report.html ${timestamp}.html\`\`\``;
+        slackMessage += `\n\nDownload test report:\n\`\`\`scp auto-e2e-wpr@xx.xx.xx.xx:~/wp-rocket-e2e/test-results-storage/${resultTimestamp}/cucumber-report.html ${resultTimestamp}.html\`\`\``;
       }
 
       await this.sendSlackMessage(slackMessage);

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -6,6 +6,7 @@ const path = require('path');
 const { spawn, exec } = require('child_process');
 const { promisify } = require('util');
 const { time } = require('console');
+const os = require('os');
 
 
 const BASE_DIR = path.dirname(path.dirname(__filename));
@@ -34,13 +35,32 @@ const CONFIG = {
   // Paths
   WORK_DIR: BASE_DIR,
   WP_ROCKET_CLONE_DIR: `${BASE_DIR}/wp-rocket`,
+  BACKWPUP_CLONE_DIR: `${BASE_DIR}/backwpup-pro`,
   E2E_DIR: `${BASE_DIR}/wp-rocket-e2e`,
   PLUGIN_DIR: `${BASE_DIR}/wp-rocket-e2e/plugin`,
   RESULTS_DIR: `${BASE_DIR}/wp-rocket-e2e/test-results-storage`,
   
   // GitHub
-  WP_ROCKET_REPO: 'https://github.com/wp-media/wp-rocket.git', // Update with actual repo URL
+  WP_ROCKET_REPO: 'https://github.com/wp-media/wp-rocket.git',
+  BACKWPUP_REPO: 'https://github.com/wp-media/backwpup-pro.git',
   
+  // Plugin Names
+  WP_ROCKET_NAME: 'WP Rocket',
+  BACKWPUP_NAME: 'BackWPUp',
+
+  //compile script
+  WP_ROCKET_COMPILE_SCRIPT: `${BASE_DIR}/compile-wp-rocket.sh`,
+  BACKWPUP_COMPILE_SCRIPT: `${BASE_DIR}/compile-backwpup.sh`,
+  // ZIP File after compilation
+  WP_ROCKET_COMPILED_ZIP_FOLDER: `${BASE_DIR}`,
+  WP_ROCKET_COMPILED_ZIP_NAME: `wp-rocket.zip`,
+  BACKWPUP_COMPILED_ZIP_FOLDER:`${BASE_DIR}/backwpup-pro/`,
+  BACKWPUP_COMPILED_ZIP_NAME_START: `backwpup-pro-en-`,
+  // ZIP File for E2E
+  WP_ROCKET_ZIP_FOR_E2E: `new_release.zip`,
+  BACKWPUP_ZIP_FOR_E2E: `backwpup.zip`,
+  
+
   // Slack webhook URL - you'll need to set this up
   SLACK_WEBHOOK_URL: process.env.SLACK_WEBHOOK_URL || '',
   
@@ -48,10 +68,10 @@ const CONFIG = {
   LOOP_INTERVAL: 5 * 60 * 1000, // 5 minutes in milliseconds
   
   // Logging
-  LOG_FILE: `${BASE_DIR}/wp-rocket-monitor.log`
+  LOG_FILE: `${BASE_DIR}/auto-e2e.log`
 };
 
-class WPRocketMonitor {
+class AutoE2ERunner {
   constructor() {
     this.isRunning = false;
     this.isCycleRunning = false;
@@ -107,40 +127,42 @@ class WPRocketMonitor {
     }
   }
 
-  async cloneOrUpdateWPRocket() {
-    this.log('Cloning/updating WP Rocket repository...');
+  async cloneOrUpdatePlugin() {
+    this.log(`Cloning/updating ${this.pluginName} repository...`);
     
-    const exists = await this.checkPathExists(CONFIG.WP_ROCKET_CLONE_DIR);
+    const exists = await this.checkPathExists(this.cloneDir);
     
     if (exists) {
       // Update existing repo
-      await this.executeCommand('git fetch origin', CONFIG.WP_ROCKET_CLONE_DIR);
-      await this.executeCommand('git reset --hard origin/develop', CONFIG.WP_ROCKET_CLONE_DIR); // or main/master
+      await this.executeCommand('git fetch origin', this.cloneDir);
+      await this.executeCommand('git reset --hard origin/develop', this.cloneDir); // or main/master
     } else {
       // Clone fresh
-      await this.executeCommand(`git clone ${CONFIG.WP_ROCKET_REPO} ${CONFIG.WP_ROCKET_CLONE_DIR}`);
+      await this.executeCommand(`git clone ${this.githubRepo} ${this.cloneDir}`);
     }
   }
 
-  async zipWPRocket() {
+  async zipPlugin() {
     try {
-      // Replace licence-data.php with the backup version
-      this.log('Replacing licence-data.php with pre-filled version...');
-      const sourceFile = path.join(CONFIG.WORK_DIR, 'licence-data.php.bak');
-      const targetFile = path.join(CONFIG.WP_ROCKET_CLONE_DIR, 'licence-data.php');
-      
-      // Check if backup file exists
-      const backupExists = await this.checkPathExists(sourceFile);
-      if (!backupExists) {
-        throw new Error(`Pre-filled licence file not found: ${sourceFile}`);
-      }
+      if (CONFIG.WP_ROCKET_NAME === this.pluginName) {
+        // Replace licence-data.php with the backup version
+        this.log('Replacing licence-data.php with pre-filled version...');
+        const sourceFile = path.join(CONFIG.WORK_DIR, 'licence-data.php.bak');
+        const targetFile = path.join(this.cloneDir, 'licence-data.php');
+        
+        // Check if backup file exists
+        const backupExists = await this.checkPathExists(sourceFile);
+        if (!backupExists) {
+          throw new Error(`Pre-filled licence file not found: ${sourceFile}`);
+        }
 
-    await this.executeCommand(`cp ${sourceFile} ${targetFile}`);
-    this.log('Successfully replaced licence-data.php');
+        await this.executeCommand(`cp ${sourceFile} ${targetFile}`);
+        this.log('Successfully replaced licence-data.php');
+    }
     
     // Run the compile script
-    this.log('Running compile-wp-rocket.sh script...');
-    const compileScript = path.join(CONFIG.WORK_DIR, 'compile-wp-rocket.sh');
+    this.log(`Running ${this.compileScript} script...`);
+    const compileScript = path.join(CONFIG.WORK_DIR, this.compileScript);
     
     // Check if compile script exists
     const scriptExists = await this.checkPathExists(compileScript);
@@ -155,9 +177,15 @@ class WPRocketMonitor {
     await this.executeCommand(`bash ${compileScript}`, CONFIG.WORK_DIR);
     
     this.log('Checking for generated ZIP file...');
-    const zipPath = path.join(CONFIG.WORK_DIR, 'wp-rocket.zip');
+    let zipPath = path.join(this.compiledZipFolder, this.compiledZipName);
     if (!fssync.existsSync(zipPath)) {
-        throw new Error('No WP Rocket ZIP file found after compilation');
+        // Find a file that starts with the compiled zip name
+        const files = fssync.readdirSync(this.compiledZipFolder);
+        const matchingFiles = files.filter(file => file.startsWith(this.compiledZipName));
+        if (matchingFiles.length == 0) {
+          throw new Error('No WP Rocket ZIP file found after compilation');
+        }
+        zipPath = path.join(this.compiledZipFolder, matchingFiles[0]);
     }
     
     const zipName = path.basename(zipPath);
@@ -166,7 +194,7 @@ class WPRocketMonitor {
     return zipPath;
     
   } catch (error) {
-    this.log(`Failed to compile WP Rocket: ${error.message}`);
+    this.log(`Failed to compile ${this.pluginName}: ${error.message}`);
     throw error;
   }
 }
@@ -178,12 +206,12 @@ class WPRocketMonitor {
     
     // Remove old wp-rocket zips to avoid clutter
     try {
-      await this.executeCommand(`rm -f ${CONFIG.PLUGIN_DIR}/new_release.zip`);
+      await this.executeCommand(`rm -f ${CONFIG.PLUGIN_DIR}/${this.zipForE2E}`);
     } catch (error) {
       this.log('No old ZIP files to remove (or removal failed)');
     }
     
-    const destinationPath = path.join(CONFIG.PLUGIN_DIR, 'new_release.zip');
+    const destinationPath = path.join(CONFIG.PLUGIN_DIR, this.zipForE2E);
     await this.executeCommand(`mv ${zipPath} ${destinationPath}`);
     
     return destinationPath;
@@ -238,74 +266,107 @@ class WPRocketMonitor {
     }
   }
 
-async deleteOldTestResults() {
-  // Delete test results folder older than 4 days
-  this.log('Deleting old test results...');
-  
-  try {
-    // Check if results directory exists
-    const dirExists = await this.checkPathExists(CONFIG.RESULTS_DIR);
-    if (!dirExists) {
-      this.log('Test results storage directory does not exist, skipping cleanup');
-      return;
-    }
-
-    const files = await fs.readdir(CONFIG.RESULTS_DIR);
-    const now = Date.now();
-    const fourDaysAgo = now - (4 * 24 * 60 * 60 * 1000); // 4 days in milliseconds
+  async deleteOldTestResults() {
+    // Delete test results folder older than 4 days
+    this.log('Deleting old test results...');
     
-    let deletedCount = 0;
-    
-    for (const file of files) {
-      const filePath = path.join(CONFIG.RESULTS_DIR, file);
-      
-      try {
-        const stats = await fs.stat(filePath);
-        if (stats.isDirectory() && stats.mtime.getTime() < fourDaysAgo) {
-          await fs.rm(filePath, { recursive: true, force: true });
-          this.log(`Deleted old test result: ${file}`);
-          deletedCount++;
-        }
-      } catch (statError) {
-        this.log(`Could not process file ${file}: ${statError.message}`);
+    try {
+      // Check if results directory exists
+      const dirExists = await this.checkPathExists(CONFIG.RESULTS_DIR);
+      if (!dirExists) {
+        this.log('Test results storage directory does not exist, skipping cleanup');
+        return;
       }
-    }
-    
-    this.log(`Old test results cleanup completed. Deleted ${deletedCount} directories.`);
-  } catch (error) {
-    this.log(`Failed to delete old test results: ${error.message}`);
-  }
-}
 
-async saveTestResults() {
-  this.log('Saving test results...');
-  
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const resultsDir = path.join(CONFIG.RESULTS_DIR, timestamp);
-  const sourceDir = path.join(CONFIG.E2E_DIR, 'test-results');
-  
-  try {
-    // Check if source directory exists and has content
-    const sourceExists = await this.checkPathExists(sourceDir);
-    if (!sourceExists) {
-      this.log('No test-results directory found, skipping save');
-      return;
+      const files = await fs.readdir(CONFIG.RESULTS_DIR);
+      const now = Date.now();
+      const fourDaysAgo = now - (4 * 24 * 60 * 60 * 1000); // 4 days in milliseconds
+      
+      let deletedCount = 0;
+      
+      for (const file of files) {
+        const filePath = path.join(CONFIG.RESULTS_DIR, file);
+        
+        try {
+          const stats = await fs.stat(filePath);
+          if (stats.isDirectory() && stats.mtime.getTime() < fourDaysAgo) {
+            await fs.rm(filePath, { recursive: true, force: true });
+            this.log(`Deleted old test result: ${file}`);
+            deletedCount++;
+          }
+        } catch (statError) {
+          this.log(`Could not process file ${file}: ${statError.message}`);
+        }
+      }
+      
+      this.log(`Old test results cleanup completed. Deleted ${deletedCount} directories.`);
+    } catch (error) {
+      this.log(`Failed to delete old test results: ${error.message}`);
     }
-
-    // Create destination directory
-    await this.createDirectoryIfNeeded(resultsDir);
-    
-    // Move files (using shell command with proper escaping)
-    await this.executeCommand(`cp -r "${sourceDir}"/* "${resultsDir}"/ && rm -rf "${sourceDir}"/*`);
-    
-    this.log(`Test results saved to: ${resultsDir}`);
-    return timestamp;
-  } catch (error) {
-    this.log(`Failed to save test results: ${error.message}`);
-    return null;
   }
-}
+
+  async saveTestResults() {
+    this.log('Saving test results...');
+    
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const resultsDir = path.join(CONFIG.RESULTS_DIR, timestamp);
+    const sourceDir = path.join(CONFIG.E2E_DIR, 'test-results');
+    
+    try {
+      // Check if source directory exists and has content
+      const sourceExists = await this.checkPathExists(sourceDir);
+      if (!sourceExists) {
+        this.log('No test-results directory found, skipping save');
+        return;
+      }
+
+      // Create destination directory
+      await this.createDirectoryIfNeeded(resultsDir);
+      
+      // Move files (using shell command with proper escaping)
+      await this.executeCommand(`cp -r "${sourceDir}"/* "${resultsDir}"/ && rm -rf "${sourceDir}"/*`);
+      
+      this.log(`Test results saved to: ${resultsDir}`);
+      return timestamp;
+    } catch (error) {
+      this.log(`Failed to save test results: ${error.message}`);
+      return null;
+    }
+  }
  
+  async configureForTestSuite(testSuite) {
+    this.log(`Configuring for test suite: ${testSuite}`);
+    // Identify which plugin is being tested
+    let pluginUnderTest = CONFIG.WP_ROCKET_NAME;
+    if (testSuite.startsWith('test:bwpup')) {
+      pluginUnderTest = CONFIG.BACKWPUP_NAME;
+    }
+
+    switch (pluginUnderTest) {
+      default:
+      case CONFIG.WP_ROCKET_NAME:
+        this.log(`Configuring for ${CONFIG.WP_ROCKET_NAME} tests...`);
+        this.cloneDir = CONFIG.WP_ROCKET_CLONE_DIR;
+        this.githubRepo = CONFIG.WP_ROCKET_REPO;
+        this.pluginName = CONFIG.WP_ROCKET_NAME;
+        this.compileScript = CONFIG.WP_ROCKET_COMPILE_SCRIPT;
+        this.compiledZipFolder = CONFIG.WP_ROCKET_COMPILED_ZIP_FOLDER;
+        this.compiledZipName = CONFIG.WP_ROCKET_COMPILED_ZIP_NAME;
+        this.zipForE2E = CONFIG.WP_ROCKET_ZIP_FOR_E2E;
+        break;
+      case CONFIG.BACKWPUP_NAME:
+        this.log(`Configuring for ${CONFIG.BACKWPUP_NAME} tests...`);
+        this.cloneDir = CONFIG.BACKWPUP_CLONE_DIR;
+        this.githubRepo = CONFIG.BACKWPUP_REPO;
+        this.pluginName = CONFIG.BACKWPUP_NAME;
+        this.compileScript = CONFIG.BACKWPUP_COMPILE_SCRIPT;
+        this.compiledZipFolder = CONFIG.BACKWPUP_COMPILED_ZIP_FOLDER;
+        this.compiledZipName = CONFIG.BACKWPUP_COMPILED_ZIP_NAME_START;
+        this.zipForE2E = CONFIG.BACKWPUP_ZIP_FOR_E2E;
+        break;
+    }
+  }
+
   async runCycle(testSuite) {
     if (this.isCycleRunning) {
       this.log('Previous cycle still running, skipping this interval...');
@@ -318,11 +379,14 @@ async saveTestResults() {
       const cycleStart = new Date();
       this.log(`Starting new cycle at ${cycleStart.toISOString()}`);
     
-      // Step 1: Clone/update WP Rocket
-      await this.cloneOrUpdateWPRocket();
+      // Configure for the specific test suite
+      await this.configureForTestSuite(testSuite);
+
+      // Step 1: Clone/update the plugin
+      await this.cloneOrUpdatePlugin();
       
       // Step 2: Create ZIP
-      const zipPath = await this.zipWPRocket();
+      const zipPath = await this.zipPlugin();
       
       // Step 3: Move ZIP to plugin directory
       await this.moveZipToPlugin(zipPath);
@@ -341,14 +405,15 @@ async saveTestResults() {
       let slackMessage = '';
       if (result.code === 0) {
         this.log(`✅ E2E tests ${testSuite} passed successfully`);
-        slackMessage = `✅ WP Rocket E2E tests ${testSuite} Ran Successfully!`;
+        slackMessage = `✅ Auto E2E tests ${testSuite} Ran Successfully!`;
       } else {
         this.log(`❌ E2E tests ${testSuite} failed`);
-        slackMessage = `❌ WP Rocket E2E tests ${testSuite} Failed!`;
+        slackMessage = `❌ Auto E2E tests ${testSuite} Failed!`;
       }
       // Add SCP download command if results were saved to facilitate downloading
       if (resultTimestamp) {
-        slackMessage += `\n\nDownload test report:\n\`\`\`scp auto-e2e-wpr@xx.xx.xx.xx:~/wp-rocket-e2e/test-results-storage/${resultTimestamp}/cucumber-report.html ${resultTimestamp}.html\`\`\``;
+        const username = os.userInfo().username;
+        slackMessage += `\n\nDownload test report:\n\`\`\`scp ${username}@xx.xx.xx.xx:~/wp-rocket-e2e/test-results-storage/${resultTimestamp}/cucumber-report.html ${resultTimestamp}.html\`\`\``;
       }
 
       await this.sendSlackMessage(slackMessage);
@@ -359,7 +424,7 @@ async saveTestResults() {
 
     } catch (error) {
       this.log(`❌ Cycle failed with error: ${error.message}`);
-      const errorMessage = `❌ WP Rocket Monitor Script Error!`;
+      const errorMessage = `❌ Auto E2E Script Error!`;
       await this.sendSlackMessage(errorMessage);
 
     } finally {
@@ -369,12 +434,12 @@ async saveTestResults() {
 
   async start(testSuite) {
     if (this.isRunning) {
-      this.log('Monitor is already running');
+      this.log('Auto E2E is already running');
       return;
     }
 
     this.isRunning = true;
-    this.log(`🚀 Starting Rocket E2E Monitor for ${testSuite}...`);
+    this.log(`🚀 Starting Auto E2E for ${testSuite}...`);
     
     // Validate configuration
     if (!await this.checkPathExists(CONFIG.E2E_DIR)) {
@@ -395,7 +460,7 @@ async saveTestResults() {
   }
 
   async stop() {
-    this.log('Stopping WP Rocket Monitor...');
+    this.log('Stopping Auto E2E...');
     this.isRunning = false;
     this.isCycleRunning = false; // Reset cycle flag
     
@@ -406,7 +471,7 @@ async saveTestResults() {
 }
 
 // Handle process termination gracefully
-const monitor = new WPRocketMonitor();
+const monitor = new AutoE2ERunner();
 
 process.on('SIGINT', async () => {
   console.log('\nReceived SIGINT, shutting down gracefully...');

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -407,7 +407,7 @@ class AutoE2ERunner {
 
       // Step 7: Analyze report and send notification if needed
       //Analyze cucumber report using analyzeCucumberReport
-      const jsonReportPath = path.join(RESULTS_DIR, resultTimestamp, 'cucumber-report.json');
+      const jsonReportPath = path.join(CONFIG.RESULTS_DIR, resultTimestamp, 'cucumber-report.json');
       const reportAnalysis = await this.analyzeCucumberReport(jsonReportPath);
       
       let slackMessage = '';

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -5,6 +5,7 @@ const fssync = require('fs');
 const path = require('path');
 const { spawn, exec } = require('child_process');
 const { promisify } = require('util');
+const { time } = require('console');
 
 
 const BASE_DIR = path.dirname(path.dirname(__filename));
@@ -298,8 +299,10 @@ async saveTestResults() {
     await this.executeCommand(`cp -r "${sourceDir}"/* "${resultsDir}"/ && rm -rf "${sourceDir}"/*`);
     
     this.log(`Test results saved to: ${resultsDir}`);
+    return timestamp;
   } catch (error) {
     this.log(`Failed to save test results: ${error.message}`);
+    return null;
   }
 }
  
@@ -330,7 +333,11 @@ async saveTestResults() {
       // Step 5: Run the test suite
       const result = await this.runE2ETests(testSuite);
       
-      // Step 6: Check exit code and send notification if needed
+      // Step 6: Maintain test results
+      await this.deleteOldTestResults();
+      const resultTimestamp = await this.saveTestResults();
+
+      // Step 7: Check exit code and send notification if needed
       let slackMessage = '';
       if (result.code === 0) {
         this.log(`✅ E2E tests ${testSuite} passed successfully`);
@@ -339,11 +346,13 @@ async saveTestResults() {
         this.log(`❌ E2E tests ${testSuite} failed`);
         slackMessage = `❌ WP Rocket E2E tests ${testSuite} Failed!`;
       }
+      // Add SCP download command if results were saved to facilitate downloading
+      if (resultTimestamp) {
+        const timestamp = path.basename(savedResultsPath);
+        slackMessage += `\n\nDownload test report:\n\`\`\`scp auto-e2e-wpr@xx.xx.xx.xx:~/wp-rocket-e2e/test-results-storage/${timestamp}/cucumber-report.html ${timestamp}.html\`\`\``;
+      }
+
       await this.sendSlackMessage(slackMessage);
-      
-      // Step 7: Maintain test results
-      await this.deleteOldTestResults();
-      await this.saveTestResults();
 
       const cycleEnd = new Date();
       const duration = cycleEnd - cycleStart;

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -49,8 +49,8 @@ const CONFIG = {
   BACKWPUP_NAME: 'BackWPUp',
 
   //compile script
-  WP_ROCKET_COMPILE_SCRIPT: `${BASE_DIR}/compile-wp-rocket.sh`,
-  BACKWPUP_COMPILE_SCRIPT: `${BASE_DIR}/compile-backwpup.sh`,
+  WP_ROCKET_COMPILE_SCRIPT: `compile-wp-rocket.sh`,
+  BACKWPUP_COMPILE_SCRIPT: `compile-backwpup.sh`,
   // ZIP File after compilation
   WP_ROCKET_COMPILED_ZIP_FOLDER: `${BASE_DIR}`,
   WP_ROCKET_COMPILED_ZIP_NAME: `wp-rocket.zip`,

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -174,7 +174,11 @@ class AutoE2ERunner {
     await this.executeCommand(`chmod +x ${compileScript}`);
     
     // Run the compile script
-    await this.executeCommand(`bash ${compileScript}`, CONFIG.WORK_DIR);
+    if (this.pluginName === CONFIG.BACKWPUP_NAME) {
+      await this.executeCommand(`bash ${compileScript} --ver 5.99.99`, CONFIG.WORK_DIR);
+    } else {
+      await this.executeCommand(`bash ${compileScript}`, CONFIG.WORK_DIR);
+    }
     
     this.log('Checking for generated ZIP file...');
     let zipPath = path.join(this.compiledZipFolder, this.compiledZipName);

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -405,14 +405,21 @@ class AutoE2ERunner {
       await this.deleteOldTestResults();
       const resultTimestamp = await this.saveTestResults();
 
-      // Step 7: Check exit code and send notification if needed
+      // Step 7: Analyze report and send notification if needed
+      //Analyze cucumber report using analyzeCucumberReport
+      const jsonReportPath = path.join(RESULTS_DIR, resultTimestamp, 'cucumber-report.json');
+      const reportAnalysis = await this.analyzeCucumberReport(jsonReportPath);
+      
       let slackMessage = '';
-      if (result.code === 0) {
+      if (reportAnalysis.failedTests === 0 && reportAnalysis.successfulTests > 0) {
         this.log(`✅ E2E tests ${testSuite} passed successfully`);
         slackMessage = `✅ Auto E2E tests ${testSuite} Ran Successfully!`;
+        slackMessage += `\n\nNumber of successful tests: ${reportAnalysis.successfulTests}`;
       } else {
         this.log(`❌ E2E tests ${testSuite} failed`);
         slackMessage = `❌ Auto E2E tests ${testSuite} Failed!`;
+        slackMessage += `\n\nNumber of failed tests: ${reportAnalysis.failedTests}`;
+        slackMessage += `\n\nFailed tests:\n${reportAnalysis.failedTestNames.join('\n')}`;
       }
       // Add SCP download command if results were saved to facilitate downloading
       if (resultTimestamp) {
@@ -470,6 +477,119 @@ class AutoE2ERunner {
     
     if (this.intervalId) {
       clearInterval(this.intervalId);
+    }
+  }
+
+  async analyzeCucumberReport(filePath) {
+    try {
+        // Read and parse the JSON file
+        const jsonData = fs.readFileSync(filePath, 'utf8');
+        const report = JSON.parse(jsonData);
+        
+        let successfulTests = 0;
+        let failedTests = 0;
+        const failedTestNames = [];
+        
+        console.log('=== CUCUMBER TEST REPORT ANALYSIS ===');
+        console.log(`Found ${report.length} feature(s)\n`);
+        
+        // Iterate through each feature
+        report.forEach((feature, featureIndex) => {
+            // Check if feature has elements (scenarios)
+            if (!feature.elements || !Array.isArray(feature.elements)) {
+                return;
+            }
+            
+            // Iterate through each scenario in the feature
+            feature.elements.forEach(scenario => {
+                // Skip background steps (they're not actual tests)
+                if (scenario.type === 'background') {
+                    return;
+                }
+                
+                const testName = scenario.name || scenario.id || 'Unnamed Test';
+                const fullTestName = `${feature.name || 'Unnamed Feature'} - ${testName}`;
+                
+                // Check if all steps in the scenario passed
+                let testPassed = true;
+                let totalSteps = 0;
+                let passedSteps = 0;
+                let failedSteps = 0;
+                let skippedSteps = 0;
+                
+                if (scenario.steps && Array.isArray(scenario.steps)) {
+                    scenario.steps.forEach(step => {
+                        totalSteps++;
+                        
+                        if (step.result && step.result.status) {
+                            switch (step.result.status) {
+                                case 'passed':
+                                    passedSteps++;
+                                    break;
+                                case 'failed':
+                                    failedSteps++;
+                                    testPassed = false;
+                                    break;
+                                case 'skipped':
+                                    skippedSteps++;
+                                    testPassed = false;
+                                    break;
+                                default:
+                                    // undefined, pending, etc.
+                                    testPassed = false;
+                                    break;
+                            }
+                        } else {
+                            // No result means the step didn't run properly
+                            testPassed = false;
+                        }
+                    });
+                }
+                
+                // Count and categorize the test
+                if (testPassed && totalSteps > 0) {
+                    successfulTests++;
+                } else {
+                    failedTests++;
+                    failedTestNames.push(fullTestName);
+                    console.log(`  ❌ ${testName} (${passedSteps} passed, ${failedSteps} failed, ${skippedSteps} skipped)`);
+                }
+            });
+        });
+        
+        // Display final results
+        console.log('\n=== FINAL RESULTS ===');
+        console.log(`Total Tests: ${successfulTests + failedTests}`);
+        console.log(`Successful Tests: ${successfulTests}`);
+        console.log(`Failed Tests: ${failedTests}`);
+        console.log('');
+        
+        if (failedTestNames.length > 0) {
+            console.log('=== FAILED TESTS ===');
+            failedTestNames.forEach((testName, index) => {
+                console.log(`${index + 1}. ${testName}`);
+            });
+        } else {
+            console.log('🎉 All tests passed!');
+        }
+        
+        return {
+            totalTests: successfulTests + failedTests,
+            successfulTests,
+            failedTests,
+            failedTestNames
+        };
+        
+    } catch (error) {
+        console.error('Error analyzing cucumber report:', error.message);
+        
+        if (error.message.includes('JSON')) {
+            console.error('Make sure the file is valid JSON format');
+        } else if (error.code === 'ENOENT') {
+            console.error('File not found. Check the file path.');
+        }
+        
+        return null;
     }
   }
 }

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -58,7 +58,7 @@ const CONFIG = {
   BACKWPUP_COMPILED_ZIP_NAME_START: `backwpup-pro-en-`,
   // ZIP File for E2E
   WP_ROCKET_ZIP_FOR_E2E: `new_release.zip`,
-  BACKWPUP_ZIP_FOR_E2E: `backwpup.zip`,
+  BACKWPUP_ZIP_FOR_E2E: `backwpup-pro.zip`,
   
 
   // Slack webhook URL - you'll need to set this up

--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -483,7 +483,7 @@ class AutoE2ERunner {
   async analyzeCucumberReport(filePath) {
     try {
         // Read and parse the JSON file
-        const jsonData = fs.readFileSync(filePath, 'utf8');
+        const jsonData = fssync.readFileSync(filePath, 'utf8');
         const report = JSON.parse(jsonData);
         
         let successfulTests = 0;


### PR DESCRIPTION
# Description

Fixes #5 
To review & merge after #4 as this branch is based on #4's one.

We now parse cucumber-report.json in the auto-e2e script to look for failed tests. We report their number and name in the Slack message and the success/failure in the slack message is based on this rather than exist status code.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

auto-e2e was updated to this branch on both WPR & BackWPUp auto-e2e runners.
The script is running as expected and returns the right Slack message.

### How to test

See auto-e2e on remote desktop + Messages in slack channel.

## Technical description

### Documentation

We parse the cucumber-report.json to count passed/failed tests.
Based on the outcome, we send the Slack message with different content.

### New dependencies

NA

### Risks

NA

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No built-in tests in this repo

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
