### PR TITLE
prevent any failure if command `chmod +x ${compileScript}` fails

### DIFF
--- a/auto-e2e.js
+++ b/auto-e2e.js
@@ -179,7 +179,11 @@ class AutoE2ERunner {
     }
     
     // Make sure the script is executable
-    await this.executeCommand(`chmod +x ${compileScript}`);
+    try {
+      await this.executeCommand(`chmod +x ${compileScript}`);
+    } catch (error) {
+      this.log(`Could not make compile script executable, continuing anyway: ${error.message}`);
+    }
     
     // Run the compile script
     if (this.pluginName === CONFIG.BACKWPUP_NAME) {


### PR DESCRIPTION
# Description

Simply wraps `chmod +x ${compileScript}` in a try-catch to avoid this failing the whole script.

If no permissions is set correctly, anyway, it will fail in the next step.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Executing the script

### How to test

`node auto-e2e.js`

### Affected Features & Quality Assurance Scope

Nothing really, it should behave the same (just that it won't fail in this specific scenario)

## Technical description

### Documentation

Simply wraps `chmod +x ${compileScript}` in a try-catch.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.